### PR TITLE
get version from xcode + set cryptoContext as optional

### DIFF
--- a/SDK/Core.swift
+++ b/SDK/Core.swift
@@ -26,8 +26,8 @@ public class PeacemakrSDK {
       return "<Unknown Peacemakr SDK version>"
     }
   }
-
-  private let cryptoContext: CryptoContext?
+  
+  private let cryptoContext: CryptoContext
   private var rand: RandomDevice
   private let apiKey: String
   private var logHandler: (String) -> Void
@@ -50,11 +50,15 @@ public class PeacemakrSDK {
   private let persister: Persister
 
   public init?(apiKey: String, logHandler: @escaping (String)->Void) {
+
+    guard let cryptoCtxt = CryptoContext() else {
+      return nil
+    }
+
     self.apiKey = apiKey
     self.logHandler = logHandler
 
-
-    self.cryptoContext = CryptoContext()
+    self.cryptoContext = cryptoCtxt
     self.rand = PeacemakrRandomDevice()
 
     self.persister = DefaultPersister(logHandler: self.logHandler)


### PR DESCRIPTION
1. Replace the hardcoded version number with the one from Xcode project. TODO: make it public? Most likely SDK customers want to know what version of SDK they're using in the code (they usually send this info to crash report system or so).
2. Set cryptoContext as Optional type. it was unsafely unwrapped `cryptoContext = cc!` in case of  failure during CryptoContext init it will throw an exception and crash the app 