### PR TITLE
func names to lowercase

### DIFF
--- a/SDK/Core.swift
+++ b/SDK/Core.swift
@@ -74,13 +74,13 @@ public class PeacemakrSDK {
     self.logHandler(logStr)
   }
   
-  public var RegistrationSuccessful: Bool {
+  public var registrationSuccessful: Bool {
     get {
       return self.persister.hasData(self.dataPrefix + self.clientIDTag) && self.persister.hasData(self.dataPrefix + self.pubKeyIDTag)
     }
   }
   
-  public func Register(completion: (@escaping (Error?) -> Void)) -> Bool {
+  public func register(completion: (@escaping (Error?) -> Void)) -> Bool {
     
     // Generate my keypair
     let myKey = PeacemakrKey(config: myKeyCfg, rand: rand)
@@ -174,7 +174,7 @@ public class PeacemakrSDK {
     return clientID!
   }
   
-  public func Sync(completion: (@escaping (Error?) -> Void)) -> Void {
+  public func sync(completion: (@escaping (Error?) -> Void)) -> Void {
     self.syncOrgInfo { (err) in
       if err != nil {
         completion(err)
@@ -552,7 +552,7 @@ public class PeacemakrSDK {
    Returns an encrypted and base64 serialized blob that contains \p plaintext.
    Throws an error on failure of encryption or serialization.
    */
-  public func Encrypt(_ plaintext: Encryptable, useDomainID: String? = nil) -> ([UInt8], Error?) {
+  public func encrypt(_ plaintext: Encryptable, useDomainID: String? = nil) -> ([UInt8], Error?) {
     let aadAndKey = self.getEncryptionKey(useDomainID: useDomainID ?? "")
     if aadAndKey == nil {
       return ([UInt8](), NSError(domain: "Unable to get the encryption key", code: -101, userInfo: nil))
@@ -616,7 +616,7 @@ public class PeacemakrSDK {
    Deserializes and decrypts \p serialized and stores the output into \p dest.
    Throws an error on failure of deserialization or decryption.
    */
-  public func Decrypt(_ serialized: [UInt8], dest: Encryptable, completion: (@escaping (Encryptable) -> Void)) -> Bool {
+  public func decrypt(_ serialized: [UInt8], dest: Encryptable, completion: (@escaping (Encryptable) -> Void)) -> Bool {
     let keyIDs = getKeyID(serialized: serialized)
     if keyIDs == nil {
       self.log("Unable to parse key IDs from message")

--- a/SDK/RandomDevice.swift
+++ b/SDK/RandomDevice.swift
@@ -17,13 +17,13 @@ public final class PeacemakrRandomDevice: RandomDevice {
         super.init()
     }
     
-    override public var Generator: RNGBuf {
+    override public var generator: RNGBuf {
         return { bytes, count in
             return SecRandomCopyBytes(kSecRandomDefault, count, bytes!)
         }
     }
     
-    override public var Err: RNGErr {
+    override public var err: RNGErr {
         return { code in
             switch code {
             case 0:

--- a/SDKTests/SDKTests.swift
+++ b/SDKTests/SDKTests.swift
@@ -37,7 +37,7 @@ class SDKTests: XCTestCase {
     
     let expectation = self.expectation(description: "Registration successful")
     
-    if !sdk!.Register(completion: {
+    if !sdk!.register(completion: {
       XCTAssert($0 == nil)
       expectation.fulfill()
     }) {
@@ -52,7 +52,7 @@ class SDKTests: XCTestCase {
   func testSync() {
     sdk = PeacemakrSDK(apiKey: testKey, logHandler: log)
     let registerExpectation = self.expectation(description: "Registration Successful")
-    XCTAssert(sdk!.Register(completion: {
+    XCTAssert(sdk!.register(completion: {
       XCTAssert($0 == nil)
       registerExpectation.fulfill()
     }), "Initialization of the SDK failed")
@@ -76,7 +76,7 @@ class SDKTests: XCTestCase {
     
     let registerExpectation = self.expectation(description: "Registration successful")
     
-    if !sdk!.Register(completion: {
+    if !sdk!.register(completion: {
       XCTAssert($0 == nil)
       registerExpectation.fulfill()
     }) {
@@ -84,14 +84,14 @@ class SDKTests: XCTestCase {
     }
     
     let syncExpectation = self.expectation(description: "Sync successful")
-    sdk!.Sync { (err) in
+    sdk!.sync { (err) in
       XCTAssert(err == nil)
       syncExpectation.fulfill()
     }
 
     waitForExpectations(timeout: 30, handler: nil)
     
-    XCTAssert(sdk!.RegistrationSuccessful, "Register failed")
+    XCTAssert(sdk!.registrationSuccessful, "Register failed")
     
     let decryptExpectation = self.expectation(description: "Decrypt successful")
     
@@ -100,7 +100,7 @@ class SDKTests: XCTestCase {
     let (serialized, err) = sdk!.Encrypt(data!)
     XCTAssert(err == nil)
     
-    XCTAssert(self.sdk!.Decrypt(serialized, dest: destination, completion: { (dest) in
+    XCTAssert(self.sdk!.decrypt(serialized, dest: destination, completion: { (dest) in
       XCTAssert(dest as! AppData == self.data!)
       decryptExpectation.fulfill()
     }))


### PR DESCRIPTION
The Swift API Design Guidelines https://swift.org/documentation/api-design-guidelines/#follow-case-conventions state that:
Names of types and protocols are UpperCamelCase. Everything else is lowerCamelCase.