### PR TITLE
Add Peacemakr Protocol and Docs to public methods

### DIFF
--- a/Peacemakr-iOS.xcodeproj/project.pbxproj
+++ b/Peacemakr-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		07FBFF4021E0045A00D9D0C6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 07FBFF3F21E0045A00D9D0C6 /* Assets.xcassets */; };
 		07FBFF4321E0045A00D9D0C6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 07FBFF4121E0045A00D9D0C6 /* LaunchScreen.storyboard */; };
 		BD055648227FB47D000A0F04 /* CoreCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD055647227FB47D000A0F04 /* CoreCrypto.framework */; };
+		BD1132E922908E2700E04E93 /* PeacemakrProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1132E822908E2700E04E93 /* PeacemakrProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -163,6 +164,7 @@
 		07FBFF4421E0045A00D9D0C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		07FBFF4821E0046300D9D0C6 /* SDKTestHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SDKTestHost.entitlements; sourceTree = "<group>"; };
 		BD055647227FB47D000A0F04 /* CoreCrypto.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CoreCrypto.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD1132E822908E2700E04E93 /* PeacemakrProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeacemakrProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,6 +283,7 @@
 				071722E8218F9996005E2CA5 /* RandomDevice.swift */,
 				071722EA218FA301005E2CA5 /* Encryptable.swift */,
 				07E235042201586000192E3C /* Persister.swift */,
+				BD1132E822908E2700E04E93 /* PeacemakrProtocol.swift */,
 			);
 			path = SDK;
 			sourceTree = "<group>";
@@ -546,6 +549,7 @@
 				0710E29F2202CB4A00CDD72A /* Contact.swift in Sources */,
 				0710E2912202CB4A00CDD72A /* JSONEncodableEncoding.swift in Sources */,
 				0710E2A32202CB4A00CDD72A /* Configuration.swift in Sources */,
+				BD1132E922908E2700E04E93 /* PeacemakrProtocol.swift in Sources */,
 				0710E29E2202CB4A00CDD72A /* LoginResponse.swift in Sources */,
 				0710E2902202CB4A00CDD72A /* CodableHelper.swift in Sources */,
 				0710E2A12202CB4A00CDD72A /* JSONEncodingHelper.swift in Sources */,

--- a/SDK/PeacemakrProtocol.swift
+++ b/SDK/PeacemakrProtocol.swift
@@ -1,0 +1,50 @@
+//
+//  PeacemakrProtocol.swift
+//  Peacemakr-iOS
+//
+//  Created by Yuliia Synytsia on 5/11/19.
+//  Copyright © 2019 Peacemakr. All rights reserved.
+//
+
+import Foundation
+
+/// Peacemakr SDK Protocol
+public protocol PeacemakrProtocol {
+  
+  /// Completion Handlers
+  typealias LogHandler = (String) -> Void
+  typealias ErrorHandler = (Error?) -> Void
+  typealias PeacemakrStrResult = (data: String?, error: Error?)
+  typealias PeacemakrDataResult = (data: Data?, error: Error?)
+  
+  
+  /// SDK version number
+  var version: String { get }
+  
+  func register(completion: (@escaping ErrorHandler))
+  
+  //  func preLoad(completion: (@escaping ErrorHandler))
+  
+  /// MARK: - Encryption
+  
+  func encrypt(plaintext: String) -> PeacemakrStrResult
+  
+  func encrypt(plaintext: Data) -> PeacemakrDataResult
+  
+  func encrypt(in domain: String, plaintext: String) -> PeacemakrStrResult
+  
+  func encrypt(in domain: String, plaintext: Data) -> PeacemakrDataResult
+  
+  /// MARK: - Decryption
+  
+  func decrypt(ciphertext: String, completion: (@escaping (PeacemakrStrResult) -> Void))
+  
+  func decrypt(ciphertext: Data, completion: (@escaping (PeacemakrDataResult) -> Void))
+  
+  /// MARK: - Utilities
+  
+  //  func getDebugInfo() -> String
+  
+  //  func releaseMemory()
+  
+}


### PR DESCRIPTION
1. Peacemakr Protocol that matches our Go SDK.
2. Docs that describes public methods in our SDK. 